### PR TITLE
Add scratch-js-website repo link to footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -15,6 +15,13 @@ export default function Footer() {
       >
         sb-edit
       </a>
+      <a
+        className="link"
+        href="https://github.com/PullJosh/scratch-js-website"
+        target="_blank"
+      >
+        scratch-js-website
+      </a>
 
       <style jsx>
         {`


### PR DESCRIPTION
This is also a test of the Zeit Now integration. Hopefully it'll work without a `now.json`?